### PR TITLE
Update inputs.conf to be disabled by default

### DIFF
--- a/twitter2/default/inputs.conf
+++ b/twitter2/default/inputs.conf
@@ -1,5 +1,5 @@
 [script://./bin/stream_tweets.py]
-disabled = 0
+disabled = 1
 index = twitter
 interval = 60
 source = twitter
@@ -7,7 +7,7 @@ sourcetype = twitter
 passAuth = splunk-system-user
 
 [script://.\bin\stream_tweets.py]
-disabled = 0
+disabled = 1
 index = twitter
 interval = 60
 source = twitter


### PR DESCRIPTION
The inputs should be defaulted to off to until configure on the target platform.
